### PR TITLE
Added User Description, Changed Update Routes to take normal JSON

### DIFF
--- a/backend stuff/httpd/rest.go
+++ b/backend stuff/httpd/rest.go
@@ -27,6 +27,7 @@ func httpHandler() http.Handler {
 	s.HandleFunc("/users/{id}/email", handler.UpdateEmail(globalDB)).Methods("PUT")
 	s.HandleFunc("/users/{id}/password", handler.UpdatePassword(globalDB)).Methods("PUT")
 	s.HandleFunc("/users/{id}/xp", handler.AddXP(globalDB)).Methods("PUT")
+	s.HandleFunc("/users/{id}/description", handler.UpdateDescription(globalDB)).Methods("PUT")
 	s.HandleFunc("/login/{email}/{password}", handler.CheckLogin(globalDB)).Methods("GET")
 	s.HandleFunc("/users/checkUsername/{username}", handler.CheckUsername(globalDB)).Methods("GET")
 


### PR DESCRIPTION
For Example:
The UpdateUsername route now accepts
{
"username": "new_username_here"
}

, instead of a single variable

There is a new description field for User. This, along with XP should not be given any value on account creation. The CreateUser function intilizes these values to "" and 0 respectively.